### PR TITLE
Remove toolbar from dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
   "engines": {
     "atom": ">0.50.0"
   },
-  "dependencies": {
-    "tool-bar": "0.1.1"
-  },
   "consumedServices": {
     "tool-bar": {
       "versions": {


### PR DESCRIPTION
APM doesn't have a mechanism for depending on other packages. The `dependencies` field in package.json is for NPM module dependencies. I can't install the package because of this.